### PR TITLE
limit snap architectures

### DIFF
--- a/cloudstats/storage.py
+++ b/cloudstats/storage.py
@@ -21,7 +21,6 @@ class Storage:
     """Storage for cloudstats."""
 
     def __init__(self, filename=None):
-
         if not filename:
             filename = os.environ.get("CLOUDSTATSDIR", ".") + "/state.db"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,10 @@ description: |
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
 parts:
   cloudstats:
     plugin: python


### PR DESCRIPTION
Snapcraft build service is currently trying to build for all architectures which is wasteful as we don't use them and builds are failing for most anyway.
This change will (hopefully) limit builds only to `amd64` and `arm64` archs which are currently passing.